### PR TITLE
Se crean los bordes para el PDF de la solicitud de Afiliaciones

### DIFF
--- a/src/components/pages/afiliados/PDFLibSolicitudAfiliacion/generarPDFLibSolicitudAfiliacion.js
+++ b/src/components/pages/afiliados/PDFLibSolicitudAfiliacion/generarPDFLibSolicitudAfiliacion.js
@@ -409,6 +409,15 @@ export async function generarPDFLibSolicitudAfiliacion({
 
     // ===================== PÁGINA N =====================
     //drawText(page, `Página ${idx + 1} de ${totalPaginas}`, 500, 20, 8, true);
+    //Bordes Externos
+    page.drawRectangle({
+      x: 20,
+      y: 75,
+      width: 595 - 40,   // 595 = ancho A4 en pt → 595 - (2*18.5)
+      height: 842 - 10,  // 842 = alto A4 en pt → 842 - (2*18.5)
+      borderColor: rgb(0, 0, 0),
+      borderWidth: 1,
+    });
   }
 
   // Guardado


### PR DESCRIPTION
Se añadieron los bordes al PDF de solicitud de Afiliaciones
<img width="1920" height="952" alt="image" src="https://github.com/user-attachments/assets/1792febc-8e0d-4f55-9b0d-d6d6cdefcdbd" />
 