### PR TITLE
Adm acceso borrado tareas 261225 dev maxi

### DIFF
--- a/src/components/pages/administracion/accesos/tareas/TareaUsuarioForm.js
+++ b/src/components/pages/administracion/accesos/tareas/TareaUsuarioForm.js
@@ -294,7 +294,11 @@ const TareaUsuarioForm = ({
 						setProcesandoTarea(true),
 						onClose(true)	
 					)}
-					disabled ={errors?.tareaExiste || procesandoTarea}
+					disabled ={
+						errors?.tareaExiste || 
+						procesandoTarea || 
+						(!hide.deletedObs && !data.deletedObs)
+					}
 					loading={procesandoTarea}
 				>
 					CONFIRMA

--- a/src/components/pages/administracion/accesos/usuarioAmbitos/UsuarioAmbitoForm.js
+++ b/src/components/pages/administracion/accesos/usuarioAmbitos/UsuarioAmbitoForm.js
@@ -323,7 +323,11 @@ const UsuarioAmbitoForm = ({
               setProcesando(true),
               onClose(true)
             )}
-            disabled ={errors?.ambitoExiste || procesando}
+            disabled ={
+              errors?.ambitoExiste || 
+              procesando || 
+              (!hide.deletedObs && !data.deletedObs)
+            }
             loading={procesando}
           >
             CONFIRMA


### PR DESCRIPTION
Actualizacion:

Se corrijio correctamente la seccion de "borrado de tarea" y "borrado de ambito",  para que el boton unicamente se habilite si el usuario ingresa la "observacion". En caso contrario estaria desabilitado.

Card asociada: https://trello.com/c/Vg7Z9PBL/811-uatre19-06-2025adm-accesos-borrado-de-tareasincidencia